### PR TITLE
fix(entities): remove redundant param

### DIFF
--- a/src/entities/include/NullTexture.hpp
+++ b/src/entities/include/NullTexture.hpp
@@ -11,9 +11,6 @@ namespace dook
      */
     class NullTexture final : public Texture
     {
-    private:
-        bool _loaded;
-
     protected:
         virtual Rect texture_size() const override
         {
@@ -21,6 +18,6 @@ namespace dook
         }
 
     public:
-        NullTexture(std::string file_name) : Texture(file_name), _loaded(false){};
+        NullTexture(std::string file_name) : Texture(file_name) {}
     };
 };

--- a/src/services/NullLevelService.cpp
+++ b/src/services/NullLevelService.cpp
@@ -14,7 +14,7 @@ dook::NullLevelService::NullLevelService() : LevelService()
         std::move(ps)));
 }
 
-bool dook::NullLevelService::load_level(std::string name)
+bool dook::NullLevelService::load_level(std::string)
 {
     return true;
 }


### PR DESCRIPTION
* Both of these cause compiler warnings for `clang++15` on my m2 mac air.
* Also they are redundant.